### PR TITLE
Bump RL Client dependency version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.35'
+def runeLiteVersion = '1.7.5'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion


### PR DESCRIPTION
Cloning the example-plugin repo leads to a gradle resolution failure on the JOGL natives. Presumably, this is some issue brought up by the new JOGL natives as part of the 1.7 release.
```
FAILURE: Build failed with an exception.

* What went wrong:
Could not find jogl-all-2.4.0-rc-20200429-natives-macosx-universal.jar (net.runelite.jogl:jogl-all:2.4.0-rc-20200429).
``` 

The JAR is actually present in the RL Repo at https://repo.runelite.net/net/runelite/jogl/jogl-all/2.4.0-rc-20200429/, but is missing a unique POM file. Perhaps this leads to the issue?

Regardless, it's fixed by just updating the RuneLite dependency version:
```diff
- def runeLiteVersion = '1.6.35'
+ def runeLiteVersion = '1.7.5'
```

Hopefully this helps prevent confusion for other new plugin creators.