### PR TITLE
build: avoid extraneous requests to RL maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,9 @@ repositories {
 	mavenLocal()
 	maven {
 		url = 'https://repo.runelite.net'
+		content {
+			includeGroupByRegex("net\\.runelite.*")
+		}
 	}
 	mavenCentral()
 }


### PR DESCRIPTION
reduce load on runelite maven repo server by excluding queries for dependencies without `net.runelite` in the group
