### PR TITLE
switch startUp / shutDown logs from info to debug

### DIFF
--- a/src/main/java/com/example/ExamplePlugin.java
+++ b/src/main/java/com/example/ExamplePlugin.java
@@ -27,13 +27,13 @@ public class ExamplePlugin extends Plugin
 	@Override
 	protected void startUp() throws Exception
 	{
-		log.info("Example started!");
+		log.debug("Example started!");
 	}
 
 	@Override
 	protected void shutDown() throws Exception
 	{
-		log.info("Example stopped!");
+		log.debug("Example stopped!");
 	}
 
 	@Subscribe


### PR DESCRIPTION
It seems that a lot of people just leave these in when submitting a new plugin. We typically tell people in hub reviews to keep log messages in non-exception / non-failure code paths as `debug` to reduce log spam.